### PR TITLE
Correct month abbrevs for June and July

### DIFF
--- a/knwl.js
+++ b/knwl.js
@@ -58,7 +58,7 @@ function Knwl() {
     this.date.days = ['1st','2nd','3rd','4th','5th','6th','7th','8th','9th','10th','11th','12th','13th','14th','15th','16th','17th','18th','19th','20th','21st','22nd','23rd',
                     '24th','25th','26th','27th','28th','29th','30th','31st'];
     this.date.months = ["january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december"];
-    this.date.monthAbbrs = ['jan','feb','mar','apr','may','june','july','aug','sept','oct','nov','dec'];
+    this.date.monthAbbrs = ['jan','feb','mar','apr','may','jun','jul','aug','sept','oct','nov','dec'];
     this.date.holidays = [['thanksgiving'],['christmas'],['new','years'],['july','4th']];
     this.date.holidaysD = [[28,11],[25,12],[1,1],[4,7]];
     this.date.dateObj = new Date();


### PR DESCRIPTION
was "june" now "jun"
was "july" now "jul"
