### PR TITLE
Fix package.json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "knwl.js",
   "description": "Scan through text for data that may be of interest.",
-  "version": "0.1",
+  "version": "0.0.1",
   "keywords": [
     "data",
     "tagging"


### PR DESCRIPTION
npm reports the version "0.1" is invalid since npm is expecting a semantic version of the form x.y.z.
