### PR TITLE
Improved the detection of phone numbers to match across multiple words.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -11,7 +11,7 @@
         
         <div class = "wrapper">
             <div class = "partOne">
-               <textarea class = "input" id = "input">I'm sorry, I'm extremely busy right now. I just looked at the clock, and it's 12:54 AM, I've still got a lot of work to do.  Don't worry about the event tomorrow, it's been moved ahead a week, the 28th of december. Remember though, you've got to call to get a ticket soon, their # is 212-323-1239 and they live at Los Angeles. Their website says it costs $23 per person. 
+               <textarea class = "input" id = "input">I'm sorry, I'm extremely busy right now. I just looked at the clock, and it's 12:54 AM, I've still got a lot of work to do.  Don't worry about the event tomorrow, it's been moved ahead a week, the 28th of december. Remember though, you've got to call to get a ticket soon, their # is 212-323-1239 and they live at Los Angeles, or call the toll free number 1 800 567-4321. Their website says it costs $23 per person. 
 If you've got enough time, they have some more information on their website, http://theevent.com.  
 Regards,
 David (david32@gmail.com)</textarea>

--- a/test/phones-spec.js
+++ b/test/phones-spec.js
@@ -1,0 +1,192 @@
+var fs = require('fs');
+var fs = require('fs');
+eval(fs.readFileSync('../knwl.js') + '');
+
+var x = new Knwl();
+
+// Test the Phone Number Detection
+describe("phone number detection", function () {
+    it("should NOT accept phones without area code", function () {
+        x.init("My phone number is 555-5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(0);
+    });
+
+    it("should NOT accept phones numbers with 8 digits", function () {
+        x.init("My phone number is 5-5555555");
+        var output = x.get("phones");
+        expect(output.length).toBe(0);
+    });
+
+    it("should accept area code + phone numbers seperated no space", function () {
+        x.init("My phone number is 5555555555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should accept area code + phone numbers seperated by hyphen", function () {
+        x.init("My phone number is 555-555-5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should accept area code + phone numbers seperated by space", function () {
+        x.init("My phone number is 555 555-5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should NOT accept area code + phone numbers seperated completely by space", function () {
+        x.init("My phone number is 555 555 5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(0);
+    });
+
+    it("should accept area code wrapped in () + phone numbers seperated by space", function () {
+        x.init("My phone number is (555) 555-5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should accept area code wrapped in () + phone numbers no space", function () {
+        x.init("My phone number is (555)555-5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should accept area code wrapped in () + phone numbers seperated by hyphen", function () {
+        x.init("My phone number is (555)-555-5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should accept area code + phone numbers seperated by space with no hyphens", function () {
+        x.init("My phone number is 555 5555555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should accept area code wrapped in () + phone numbers seperated by space with no hyphens", function () {
+        x.init("My phone number is (555) 5555555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should accept country code + area code + phone numbers seperated by hyphen", function () {
+        x.init("My phone number is 5-555-555-5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should accept country code + area code + phone numbers seperated by space", function () {
+        x.init("My phone number is 5 555 555-5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should accept country code + (area code) + phone numbers seperated by space", function () {
+        x.init("My phone number is 5 (555) 555-5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should accept (country code) + (area code) + phone numbers no space", function () {
+        x.init("My phone number is (5)(555)555-5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+    it("should accept +country code + (area code) + phone numbers seperated by space", function () {
+        x.init("My phone number is +5 (555) 555-5555");
+        var output = x.get("phones");
+        expect(output.length).toBe(1);
+    });
+
+});
+
+// Test the Phone Number Formatting
+describe("phone number formatting", function() {
+    it("should turn ########## into (###) ###-####", function() {
+        x.init("My phone number is 5555555555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("(555) 555-5555");
+    });
+
+    it("should turn ###-###-#### into (###) ###-####", function () {
+        x.init("My phone number is 555-555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("(555) 555-5555");
+    });
+
+    it("should turn ### ###-#### into (###) ###-####", function () {
+        x.init("My phone number is 555 555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("(555) 555-5555");
+    });
+
+    it("should turn (###) ###-#### into (###) ###-####", function () {
+        x.init("My phone number is (555) 555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("(555) 555-5555");
+    });
+
+    it("should turn (###)###-#### into (###) ###-####", function () {
+        x.init("My phone number is (555)555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("(555) 555-5555");
+    });
+
+    it("should turn (###)-###-#### into (###) ###-####", function () {
+        x.init("My phone number is (555)-555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("(555) 555-5555");
+    });
+
+    it("should turn ### ####### into (###) ###-####", function () {
+        x.init("My phone number is 555 5555555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("(555) 555-5555");
+    });
+
+    it("should turn #-###-###-#### into +# (###) ###-####", function () {
+        x.init("My phone number is 5-555-555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("+5 (555) 555-5555");
+    });
+
+    it("should turn # ### ###-#### into +# (###) ###-####", function () {
+        x.init("My phone number is 5 555 555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("+5 (555) 555-5555");
+    });
+
+    it("should turn # (###) ###-#### into +# (###) ###-####", function () {
+        x.init("My phone number is 5 (555) 555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("+5 (555) 555-5555");
+    });
+
+    it("should NOT recnognize country code wrapped in brackets", function () {
+        x.init("My phone number is (5) 555-555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("(555) 555-5555");
+    });
+
+    it("should turn +# (###) ###-#### into +# (###) ###-####", function () {
+        x.init("My phone number is +5 (555) 555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("+5 (555) 555-5555");
+    });
+
+    it("should turn ##-###-###-#### into +## (###) ###-####", function () {
+        x.init("My phone number is 55-555-555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("+55 (555) 555-5555");
+    });
+
+    it("should turn ###-###-###-#### into +### (###) ###-####", function () {
+        x.init("My phone number is 555-555-555-5555");
+        var output = x.get("phones");
+        expect(output[0][0]).toBe("+555 (555) 555-5555");
+    });
+});


### PR DESCRIPTION
Detecting the phone number, required area code (assumed to be 3 digits currently), and optionally country code
which can be between 1 and 3 digits long can now be done across multiple words rather than requiring all to be hyphenated.
Added a this.phone.formatPhoneNumber(number) function to format the numbers to a common looking string
Added a high-level this.removeCharacters(charArray, str) which will remove all of the specified characters
in the charArray array from the specified str string. This is useful for escaping some common characters appearing
in phone numbers including '(',')','-','+', etc.
Added jasmine unit tests in the tests package.
