### PR TITLE
Improve Email tests

### DIFF
--- a/test/emails-spec.js
+++ b/test/emails-spec.js
@@ -37,6 +37,16 @@ describe("email", function() {
         });
     };
 
+    // Uncomment me when issue #35 is solved
+    // for (var i = ValidEmails.length - 1; i >= 0; i--) {
+    //     var ve = ValidEmails[i];
+    //     it("should detect the valid email of " + ve + " that ends in a full stop", function() {
+    //         x.init("You can reach me on " + ve + ".");
+    //         var output = x.get("emails")
+    //         expect(output[0][0]).toBe(ve);
+    //     });
+    // };
+
     for (var i = InvalidEmails.length - 1; i >= 0; i--) {
         var ie = InvalidEmails[i];
         it("should not detect the email of " + ie, function() {


### PR DESCRIPTION
This way anyone can add to them with out really thinking much by just adding to the list that looks like:

``` javascript
var ValidEmails = [
    "test@test.com",
    "test@test.co.uk",
    "test.test@test.com",
    "test+test@test.com",
    "sir.Test+testing@test.com",
    "test@testdeparetment.testcorp.com",
    "12341234@123.com",
    "123123123@test.com",
    "test@10.0.0.1",
    "test-man@test.com",
    "test@test-corp.com"
];
```

There is also a _invalid_ list too that looks like:

``` javascript
var InvalidEmails = [
    ".@test.com",
    "@",
    "what",
    "",
    "@test.com",
    "test@test",
    "あいうえお@example.com"
];
```

If anyone has any more cases I should consider please do comment!
