### PR TITLE
Added the dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "engines": {
     "node": "*"
   },
+  "dependencies": {
+    "jasmine-node": "*",
+    "uglify-js": "*"
+  },
   "scripts": {
     "build": "uglifyjs -o ./knwl.min.js ./knwl.js"
   }


### PR DESCRIPTION
Now after cloning the project, they only need to run `npm install -g` from the base project directory to globally and recursively install all required node modules (keep in mind if someone just runs `npm install` the node_modules folder will appear in the base project directory. Should consider adding a .gitignore if you do not want the node_modules folder appearing in the project). 

This will create an easier way for all contributors to manage/install dependencies for the project.
