### PR TITLE
Switched package.json dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "engines": {
     "node": "*"
   },
-  "dependencies": {
+  "devDependencies": {
     "jasmine-node": "*",
     "uglify-js": "*"
   },


### PR DESCRIPTION
The jasmine-node and uglify-js are development dependencies not project ones and should therefore be included under devDependencies. If someone is going to be referencing this project we don't want them to necessarily have to also download jasmine-node and uglify-js.
