### PR TITLE
adjust indentation for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ These are automatically loaded by default.
 
 ###dates.js
 ```javascript
-	knwl.get('dates');
+knwl.get('dates');
 	
 	//Returns any dates found in the String.
 ```
 
 ###times.js
 ```javascript
-	knwl.get('times');
+knwl.get('times');
 	
 	//Returns any times found in the String.
 	


### PR DESCRIPTION
dates.js and times.js were inconsistently indented in relation to the other default plugins. this change improves readability

Before:
![screen shot 2015-06-05 at 9 15 58 pm](https://cloud.githubusercontent.com/assets/7812178/8018289/fe537f3c-0bc8-11e5-959c-29f42fa89e32.png)

After:
![screen shot 2015-06-05 at 9 21 34 pm](https://cloud.githubusercontent.com/assets/7812178/8018290/079b5e98-0bc9-11e5-8480-ed343de2a6eb.png)
