### PR TITLE
Ratios

### DIFF
--- a/experimental_plugins/ratios.js
+++ b/experimental_plugins/ratios.js
@@ -1,0 +1,49 @@
+                                                                  // This plugin recognizes ratios (https://en.wikipedia.org/wiki/Ratio#Proportions_and_percentage_ratios)
+                                                                  // Note: Does not support irrational fractions.
+                                                                  // returns: {context: String, value: String, percentileValue: Int}
+
+function Ratios(knwlInstance) {
+    var types = [
+
+        {                                                         // regular percent: 12938,1231%
+            percentile: function(value) { return +value.substring(0, value.length - 1)},
+            regEx: '[0-9]*[\.|,]?[0-9]*\%'
+        },
+
+        {                                                         // fractions with colon or slash: 9:30; 12/123
+            percentile: function(value) { return eval(value.replace(':','/'))* 100},
+            regEx: '[0-9]*[\:|\/][0-9]*'
+        }
+
+    ]
+
+
+    this.calls = function() {
+        var words = knwlInstance.words.get('words');              // get the String as an array of words
+
+        var results = [];                                         // prepare results
+
+        words.forEach( function(word) {                           // check each word
+            types.some( function(type) {                          // for each type
+
+                var regEx = new RegExp(type.regEx);               // load regeEx
+                var regExRes = regEx.exec(word);                  // execute this regex on this word
+
+                if(regExRes != null){                             // if it worked out, prepare a res to push
+                    var res = {};
+
+                    res.context = word;                           // context = entire word.
+                    value = regExRes[0]
+                    res.value = value;
+                    res.percentileValue = type.percentile(value); // context = entire word.
+                    results.push(res);
+                    return true;                                  // break when found
+                }
+            });
+        });
+
+        return results;
+    };
+}
+
+module.exports = Ratios;

--- a/test/ratios-spec.js
+++ b/test/ratios-spec.js
@@ -1,0 +1,27 @@
+var Knwl = require('../knwl');
+var knwl = new Knwl();
+knwl.register('ratios', require('../experimental_plugins/ratios'));
+
+// Test Ratio Detection
+describe("ratio detection", function () {
+    it("should detect percent", function () {
+        knwl.init("We have a 89% chance of success.");
+        var output = knwl.get("ratios");
+        expect(output[0].value).toBe("89%");
+    });
+    it("should detect a fraction", function () {
+        knwl.init("Thirty percent of us are 5/6 intelligent.");
+        var output = knwl.get("ratios");
+        expect(output[0].value).toBe("5/6");
+    });
+    it("should detect a fraction denoted with a colon", function () {
+        knwl.init("Le professeur disait que on mange 3:4 de le fromage.");
+        var output = knwl.get("ratios");
+        expect(output[0].value).toBe("3:4");
+    });
+    it("should detect a percentile that is mutated into a German adjective", function () {
+        knwl.init("Nationalismus ist ein 100%ig hirnrissiges Konzept.");
+        var output = knwl.get("ratios");
+        expect(output[0].value).toBe("100%");
+    });
+});


### PR DESCRIPTION
The code should be quite clean. Let me know if there are any issues.
This is currently an experimental plugin because:
- `12:30` is usually not a ratio but some time of the day. Yet still it gets recognized as a ratio.
- `context` is not tested and unstable.

I will implement a matcher for financial values in the following days. Not sure if a new release makes sense before both plugins are merged.