### PR TITLE
Fix knwl freezing application when getting links

### DIFF
--- a/default_plugins/links.js
+++ b/default_plugins/links.js
@@ -11,7 +11,14 @@ function Links(knwl) {
 
         for (var i = 0; i < words.length; i++) {
             var word = words[i].replace(/[\(\)!]/g, ""); // replaces every bracket ')' or '(' and every '!' with an empty character
-            if (/^(https?|ftp):\/\/(-\.)?([^\s\/?\.#-]+\.?)+(\/[^\s]*)?$/i.test(word)) {
+            
+            // https://stackoverflow.com/a/3809435
+            var expression =
+                /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi
+            
+            var regex = new RegExp(expression)
+
+            if (regex.test(word)) {
                 var link = word;
                 if (link[link.length - 1].search(/[?.!,]/g) !== -1) {
                     link = link.substr(0, link.length-1);


### PR DESCRIPTION
Current regex in `links.js` causes catastrophic backtracking when testing certain urls e.g. `https://makeawishmetronewyorkandwesternnewyork-v.com` 